### PR TITLE
Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+# Loosely based on https://github.com/manubot/rootstock/blob/1780fac0ac6bba1260a9da3886061730fa5d2765/ci/install.sh
+language: minimal
+
+notifications:
+  email: false
+
+before_install:
+  - wget https://repo.continuum.io/miniconda/Miniconda3-py37_4.8.2-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - source $HOME/miniconda/etc/profile.d/conda.sh
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda env create --quiet --file env/minimal-environment.yml
+  - conda list --name prmf
+  - conda activate prmf
+
+install:
+  - pip install .
+
+script:
+  - python -c "import prmf"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# prmf
-Pathway-Regularized Matrix Factorization
+# Pathway-Regularized Matrix Factorization (PRMF)
+[![Build Status](https://travis-ci.com/gitter-lab/prmf.svg?branch=master)](https://travis-ci.com/gitter-lab/prmf)
 
 ![Graphical abstract of Pathway-Regularized Matrix Factorization](doc/abstract.png)
 
@@ -7,14 +7,14 @@ Pathway-Regularized Matrix Factorization
 
 ## Dependencies
 - Python (3.7.0)
--- numpy
--- scipy
--- matplotlib
--- sklearn
--- networkx
+  - numpy
+  - scipy
+  - matplotlib
+  - sklearn
+  - networkx
 - R (3.5.1)
--- KEGGREST
--- KEGGgraph
--- graph
--- igraph
--- argparse
+  - KEGGREST
+  - KEGGgraph
+  - graph
+  - igraph
+  - argparse

--- a/env/minimal-environment.yml
+++ b/env/minimal-environment.yml
@@ -1,0 +1,10 @@
+name: prmf
+channels:
+  - defaults
+dependencies:
+  - matplotlib=2.1
+  - networkx=1.11
+  - numpy=1.14
+  - python=3.7
+  - scikit-learn=0.19
+  - scipy=1.0

--- a/env/minimal-environment.yml
+++ b/env/minimal-environment.yml
@@ -2,9 +2,9 @@ name: prmf
 channels:
   - defaults
 dependencies:
-  - matplotlib=2.1
+  - matplotlib=3.1
   - networkx=1.11
-  - numpy=1.14
-  - python=3.7
-  - scikit-learn=0.19
-  - scipy=1.0
+  - numpy=1.18
+  - python=3.7.6
+  - scikit-learn=0.22
+  - scipy=1.4


### PR DESCRIPTION
Closes #5

Currently, no tests are run.  Miniconda is installed along with a minimal prmf environment that supports the prmf package.