### PR TITLE
Initial steps toward building and deploying Portray docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+prmf/__pycache__/
 script/__pycache__/
 build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - wget https://github.com/manubot/manubot/blob/a4c826ceb954635810ba204a2393dce6fa7a5d5a/ci/deploy-docs.sh
 
 script:
-  - python -c "import prmf; print(prmf.__version__)"
+  - python -c "import prmf"
     # See https://github.com/manubot/manubot/blob/a4c826ceb954635810ba204a2393dce6fa7a5d5a/.travis.yml#L23
   - export PYTHONPATH=.
   - portray as_html --overwrite --output_dir=docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,6 @@ deploy:
     script: bash deploy-docs.sh
     skip_cleanup: true
     on:
-      repo: manubot/manubot
+      repo: gitter-lab/prmf
       branch: master
       condition: $TRAVIS_EVENT_TYPE = "push"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,25 @@ before_install:
   - conda activate prmf
 
 install:
+  - pip install portray==1.3.1
   - pip install .
+  # Use Manubot portray docs deploy script
+  # Include this in repository with attribution if it works well
+  - wget https://github.com/manubot/manubot/blob/a4c826ceb954635810ba204a2393dce6fa7a5d5a/ci/deploy-docs.sh
 
 script:
-  - python -c "import prmf"
+  - python -c "import prmf; print(prmf.__version__)"
+    # See https://github.com/manubot/manubot/blob/a4c826ceb954635810ba204a2393dce6fa7a5d5a/.travis.yml#L23
+  - export PYTHONPATH=.
+  - portray as_html --overwrite --output_dir=docs
+
+# Deploy procedure from Manubot
+# https://github.com/manubot/manubot/blob/a4c826ceb954635810ba204a2393dce6fa7a5d5a/.travis.yml
+deploy:
+  - provider: script
+    script: bash deploy-docs.sh
+    skip_cleanup: true
+    on:
+      repo: manubot/manubot
+      branch: master
+      condition: $TRAVIS_EVENT_TYPE = "push"


### PR DESCRIPTION
Related to #6

This closely follows the portray documentation deployment from https://github.com/manubot/manubot/pull/153 It even downloads the Manubot deploy script in this initial draft.  I'll have to merge and do more testing on the master branch because docs are only deployed on master branch builds.